### PR TITLE
fixed bug: in firefox keypress on enter is not parsed property

### DIFF
--- a/keysight.js
+++ b/keysight.js
@@ -168,7 +168,8 @@ for(var x in keydownKeycodeDictionary) {
 }
 
 var keypressCharacterMap = {
-    '\r':'\n'
+    '\r':'\n',
+    '\u0000': '\n' // In firefox keypress on enter is represented as \u0000
 }
 var keydownCharacterMap = {
     num_subtract: '-',


### PR DESCRIPTION
Expected: keysight(e).key === '\n'
Actual: keysight(e).key === '\u0000'